### PR TITLE
typo: accross -> across

### DIFF
--- a/docs-ref-autogen/vss-web-extension-sdk/VSS.Gallery.Contracts.ReviewSummary.yml
+++ b/docs-ref-autogen/vss-web-extension-sdk/VSS.Gallery.Contracts.ReviewSummary.yml
@@ -55,7 +55,7 @@ items:
     langs:
       - typeScript
     type: property
-    summary: Split of count accross rating
+    summary: Split of count across rating
     syntax:
       content: 'RatingCountPerRating[] ratingSplit'
       return:


### PR DESCRIPTION
This is likely auto-generated, but i'm not sure about the source